### PR TITLE
Force shutdown without asking for unsaved changes

### DIFF
--- a/xxUSBSentinel/Form1.cs
+++ b/xxUSBSentinel/Form1.cs
@@ -257,7 +257,7 @@ namespace xxUSBSentinel {
             ListBox1.Items.Add(now + ": " + STR);
         }
         private void SleepTightSweetPrince() {
-            var psi = new ProcessStartInfo("shutdown", "/s /t 0");
+            var psi = new ProcessStartInfo("shutdown", "/s /t 0 /f");
             psi.CreateNoWindow = true;
             psi.UseShellExecute = false;
             Process.Start(psi);


### PR DESCRIPTION
Just a little `/f` added to the shutdown command to force a shutdown to avoid the awkward message about unsaved changes when you really just want to shut down >quickly<.

https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/shutdown